### PR TITLE
fix: message sent date formatting when null

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "1f7fa5ca-ee75-419d-9e82-8f2e33a2fe99",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "requiredApiVersion": "^1.19.0",
     "iconFile": "icon.png",
     "author": {

--- a/src/remote/rapidpro/RapidproRestApi.ts
+++ b/src/remote/rapidpro/RapidproRestApi.ts
@@ -30,7 +30,8 @@ export default class RapidProRestApi implements IRapidProRemoteDataSource {
 
         response.data.results.forEach((message) => {
             if (message.status !== 'errored') {
-                const sentOn = DateStringUtils.format(DateStringUtils.addMinutes(message.sent_on, tzOffset), 'dd/MM/yyyy, hh:mm');
+                const date = message.sent_on ?? message.created_on;
+                const sentOn = DateStringUtils.format(DateStringUtils.addMinutes(date, tzOffset), 'dd/MM/yyyy, hh:mm');
 
                 message.text && result.push({ direction: message.direction, sentOn, text: message.text } as RPMessage);
                 message.attachments.forEach((attachment) => {


### PR DESCRIPTION
When returning the Push messages, it may happen that the field 'sent_on' is null while the message has not yet arrived on whatsapp. Added verification, for when null use the 'created_on' field.

![image](https://user-images.githubusercontent.com/44068957/110355943-82629000-8018-11eb-997d-9cc6cad7b0ca.png)
